### PR TITLE
Iframe reloading

### DIFF
--- a/app/webcomponents/package.json
+++ b/app/webcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@updater/ui-storybook-webcomponents",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Storybook for Webcomponents: Develop Webcomponents in isolation with Hot Reloading.",
   "homepage": "https://github.com/storybooks/storybook/tree/master/app/webcomponents",
   "bugs": {

--- a/app/webcomponents/package.json
+++ b/app/webcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@updater/ui-storybook-webcomponents",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Storybook for Webcomponents: Develop Webcomponents in isolation with Hot Reloading.",
   "homepage": "https://github.com/storybooks/storybook/tree/master/app/webcomponents",
   "bugs": {

--- a/app/webcomponents/package.json
+++ b/app/webcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@updater/ui-storybook-webcomponents",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Storybook for Webcomponents: Develop Webcomponents in isolation with Hot Reloading.",
   "homepage": "https://github.com/storybooks/storybook/tree/master/app/webcomponents",
   "bugs": {

--- a/app/webcomponents/src/client/preview/index.js
+++ b/app/webcomponents/src/client/preview/index.js
@@ -39,7 +39,14 @@ if (isBrowser) {
   // create preview channel
   const channel = createChannel({ page: 'preview' });
   channel.on('setCurrentStory', data => {
-    reduxStore.dispatch(Actions.selectStory(data.kind, data.story));
+    // If we're in the same kind just use redux, otherwise we need to reload the
+    // iframe to prevent redefination of potentially shared webcomponents
+    const previousKind = window.location.search.match(/selectedKind=([a-z-]*)/);
+    if ((previousKind && previousKind[1]) === data.kind) {
+      reduxStore.dispatch(Actions.selectStory(data.kind, data.story));
+    } else {
+      window.location.assign(`iframe.html?selectedKind=${data.kind}&selectedStory=${data.story}`);
+    }
   });
   addons.setChannel(channel);
   Object.assign(context, { channel });

--- a/app/webcomponents/src/client/preview/render.js
+++ b/app/webcomponents/src/client/preview/render.js
@@ -52,8 +52,8 @@ export function renderMain(data, storyStore) {
     story: selectedStory,
   };
 
-  let storyString = story ? story(context) : '<p>There is no preview for this story</p>';
-  storyString = scopeScripts(storyString);
+  const storyString = story ? story(context) : '<p>There is no preview for this story</p>';
+
   if (storyString.then) {
     storyString.then(renderStoryString);
   } else {

--- a/app/webcomponents/src/client/preview/render.js
+++ b/app/webcomponents/src/client/preview/render.js
@@ -25,8 +25,8 @@ export function renderException(error) {
 }
 
 function scopeScripts(storyString) {
-  let escapedScripts = storyString.replace('<script>', '<script>{');
-  escapedScripts = escapedScripts.replace('</script>', '}</script>');
+  let escapedScripts = storyString.replace(new RegExp('<script>'), '<script>{');
+  escapedScripts = escapedScripts.replace(new RegExp('</script>'), '}</script>');
   return escapedScripts;
 }
 

--- a/app/webcomponents/src/client/preview/render.js
+++ b/app/webcomponents/src/client/preview/render.js
@@ -30,6 +30,16 @@ function scopeScripts(storyString) {
   return escapedScripts;
 }
 
+function renderStoryString(story) {
+  const storyString = scopeScripts(story);
+
+  const root = document.querySelector('#root');
+  emptyRoot(root);
+
+  const child = createFragment(storyString);
+  root.appendChild(child);
+}
+
 export function renderMain(data, storyStore) {
   if (storyStore.size() === 0) return;
 
@@ -44,12 +54,11 @@ export function renderMain(data, storyStore) {
 
   let storyString = story ? story(context) : '<p>There is no preview for this story</p>';
   storyString = scopeScripts(storyString);
-
-  const root = document.querySelector('#root');
-  emptyRoot(root);
-
-  const child = createFragment(storyString);
-  root.appendChild(child);
+  if (storyString.then) {
+    storyString.then(renderStoryString);
+  } else {
+    renderStoryString(storyString);
+  }
 }
 
 export default function renderPreview({ reduxStore, storyStore }, forceRender = false) {


### PR DESCRIPTION
These changes cause the preview `iframe` to reload when a different story kind is loaded. This is allows the custom element definitions within the story kinds to be sandboxed and prevents conflicts. In addition this adds support for promises so that way codesplitting, through webpack's `import()`, can be done to split out the bundles of the stories and actually sandbox them.